### PR TITLE
Add some nullable properties to Client

### DIFF
--- a/shared/Client.cs
+++ b/shared/Client.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Text.Json.Serialization;
 
 namespace TrainingApi.Shared;
 
@@ -13,6 +14,9 @@ namespace TrainingApi.Shared;
 /// <param name="Weight">The weight of the client in pounds, rounded to the nearest pound.</param>
 /// <param name="Height">The height of the client in inches, rounded to the nearest inch.</param>
 /// <param name="BirthDate">The date of birth of the client.</param>
+
+
+
 public record Client(
     int Id,
     string FirstName,
@@ -21,4 +25,32 @@ public record Client(
     int Weight,
     int Height,
     DateTime BirthDate
-);
+) {
+    /// <summary>The date of the last workout of the client.</summary>
+    public DateOnly? LastWorkout { get; set; } = null;
+    /// <summary>The training goal of the client.</summary>
+    public TrainingGoal? Goal { get; set; } = null;
+    /// <summary>Notes about the client.</summary>
+    public string? Notes { get; set; } = null;
+};
+
+/// <summary>
+/// The training goals of the client.
+/// </summary>
+/// <param name="FatLoss">Fat Loss</param>
+/// <param name="MuscleGain">Muscle Gain</param>
+/// <param name="Endurance">Endurance</param>
+/// <param name="Flexibility">Flexibility</param>
+/// <param name="Strength">Strength</param>
+/// <param name="GeneralHealth">General Health</param>
+///
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum TrainingGoal
+{
+    FatLoss,
+    MuscleGain,
+    Endurance,
+    Flexibility,
+    Strength,
+    GeneralHealth
+}

--- a/src/TrainingApi.json
+++ b/src/TrainingApi.json
@@ -382,6 +382,24 @@
             "type": "string",
             "description": "The date of birth of the client.",
             "format": "date-time"
+          },
+          "lastWorkout": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "description": "The date of the last workout of the client.",
+            "format": "date"
+          },
+          "goal": {
+            "$ref": "#/components/schemas/NullableOfTrainingGoal"
+          },
+          "notes": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "description": "Notes about the client."
           }
         },
         "description": "Represents a client with personal information.",
@@ -392,7 +410,7 @@
           "email": "jane.smith@email.com",
           "weight": 60,
           "height": 170,
-          "birthDate": "1990-01-01T00:00:00.0000000-08:00"
+          "birthDate": "1990-01-01T00:00:00.0000000+00:00"
         }
       },
       "Level": {
@@ -402,6 +420,18 @@
           "Elite"
         ],
         "description": "The level of the trainer."
+      },
+      "NullableOfTrainingGoal": {
+        "enum": [
+          "FatLoss",
+          "MuscleGain",
+          "Endurance",
+          "Flexibility",
+          "Strength",
+          "GeneralHealth",
+          null
+        ],
+        "description": "The training goal of the client."
       },
       "Trainer": {
         "type": "object",


### PR DESCRIPTION
This PR just adds a few nullable properties of different types to the client model, to demonstrate how nullables are rendered in OpenAPI 3.1 documents.