### PR TITLE
Remove global.json in 9.0 branch for release

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "9.0.200",
-    "rollForward": "latestMajor"
-  }
-}

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-rc.2.24474.11"
+    "version": "9.0.200",
+    "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
This pull request removes the `global.json` file, which previously specified the .NET SDK version for the project. This isn't really needed anymore since .NET 9 is released.